### PR TITLE
fix: update LimaCharlie templates to use single license secret key

### DIFF
--- a/charts/limacharlie/templates/limacharlie-daemonset.yaml
+++ b/charts/limacharlie/templates/limacharlie-daemonset.yaml
@@ -21,16 +21,11 @@ spec:
         env:
         - name: K8S_POD_LOGS
           value: /k8s-pod-logs
-        - name: OID
+        - name: LICENSE
           valueFrom:
             secretKeyRef:
               name: limacharlie-license
-              key: OID
-        - name: IKEY
-          valueFrom:
-            secretKeyRef:
-              name: limacharlie-license
-              key: IKEY
+              key: license
         - name: NAME
           value: {{ .Values.name }}
       volumes:

--- a/charts/limacharlie/templates/limacharlie-secret.yaml
+++ b/charts/limacharlie/templates/limacharlie-secret.yaml
@@ -12,11 +12,6 @@ spec:
     name: "{{ .Values.limacharlie.agent.name }}-license"
     creationPolicy: Owner
   data:
-    - secretKey: OID
+    - secretKey: license
       remoteRef:
         key: LIMACHARLIELICENSE
-        property: OID
-    - secretKey: IKEY
-      remoteRef:
-        key: LIMACHARLIELICENSE
-        property: IKEY

--- a/charts/limacharlie/templates/limacharlie-sensor-daemonset.yaml
+++ b/charts/limacharlie/templates/limacharlie-sensor-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.limacharlie.agent.name }}-license"
-                  key: IKEY
+                  key: license
             - name: LC_TAGS
               value: {{ .Values.sensor.tags | quote }}
           securityContext:


### PR DESCRIPTION
# Closes [TECH-160](https://firstclose.atlassian.net/jira/software/projects/TECH/boards/95/backlog?assignee=712020%3A235e802e-1c2e-4b07-b9af-e68f5d7fa32a%2C640a89720a4a47fb8d25819f%2C63d2dd8b8c3018ca8a1c5747&selectedIssue=TECH-160)


## :bookmark_tabs: Change Description

Fixes the ExternalSecret configuration for the LimaCharlie deployment in `helm-charts`.  
Previously, the ExternalSecret attempted to extract `OID` and `IKEY` from the Azure Key Vault secret `LIMACHARLIELICENSE`, but the secret contains a single raw value.  
Now it's updated to extract a single `license` key and wire it correctly to the adapter and sensor.



## :white_check_mark: Change Introduces

This pull request targets a
- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Support
- [ ] Enhancement

## What type of changes are being introduced?
- [ ] :red_circle: Breaking changes
- [x] :green_circle: Non-breaking changes

## :man_technologist: How should this be tested by QA?
- Deploy this chart via ArgoCD to the `staging` cluster
- Ensure the ExternalSecret syncs successfully and creates a Kubernetes Secret named `limacharlie-license`
- Check the `lc-adapter-k8s-pods` and `limacharlie-agent` DaemonSets start without crashing
- Validate LimaCharlie is receiving logs and telemetry from the cluster

## :computer: Pre-requisites to deploy to Production?


## :ledger:	Any background context you want to provide beyond Jira?

The original configuration assumed the Key Vault secret was a JSON object with `OID` and `IKEY` properties, but LimaCharlie provided a single token string instead.

## :camera_flash: Screenshots (if needed)

xxx

## :clapper: Any Video (if needed)

xxx

## :police_officer:	Any possible security issues

xxx


[TECH-160]: https://firstclose.atlassian.net/browse/TECH-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ