### PR TITLE
fixed: tolerance to win clusters

### DIFF
--- a/charts/limacharlie/templates/limacharlie-sensor-daemonset-win.yaml
+++ b/charts/limacharlie/templates/limacharlie-sensor-daemonset-win.yaml
@@ -16,6 +16,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
+      tolerations:
+        - key: "os"
+          operator: "Equal"
+          value: "Windows"
+          effect: "NoSchedule"
       containers:
         - name: {{ .Values.limacharlie.agent.name }}
           image: {{ .Values.sensor.image }}


### PR DESCRIPTION
# Closes [TECH-479](https://firstclose.atlassian.net/browse/TECH-160?atlOrigin=eyJpIjoiOTRjN2JiMjQ5NzI1NDhiYjlhMGRhZjQ0MDE4NDVmZjYiLCJwIjoiaiJ9)

## :bookmark_tabs: Change Description

Fixed tolerance in limacharlie-sensor-daemonset-win.yaml to be able to run deamonset in nodes
## :white_check_mark: Change Introduces

This pull request targets a
- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Support
- [ ] Enhancement

## What type of changes are being introduced?
- [ ] :red_circle: Breaking changes
- [x] :green_circle: Non-breaking changes


## :computer: Pre-requisites to deploy to Production?

<!--
  Is there any pre-requisites to deploy to Staging/Production? If none, please delete this section.

N/A

## :ledger:	Any background context you want to provide beyond Jira?

N/A
## :camera_flash: Screenshots (if needed)

N/A
## :clapper: Any Video (if needed)

N/A
## :police_officer:	Any possible security issues

N/A

[TECH-479]: https://firstclose.atlassian.net/browse/TECH-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ