### PR TITLE
TECH-620: added kafkanodepool setup for different envs for kraft architecture

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kafka
 description: Kafka deployment as a Helm Chart
 type: application
-version: 3.0.3
-appVersion: "3.0.3"
+version: 3.1.0
+appVersion: "3.1.0"

--- a/charts/kafka/templates/KafkaNodePool.yml
+++ b/charts/kafka/templates/KafkaNodePool.yml
@@ -1,6 +1,6 @@
 # create a single nodepool with both broker and controller roles for lower-envs
 
-{{- if not .Values.isProd }}
+{{- if not .Values.separatedPools }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:

--- a/charts/kafka/templates/KafkaNodePool.yml
+++ b/charts/kafka/templates/KafkaNodePool.yml
@@ -1,20 +1,73 @@
+# create a single nodepool with both broker and controller roles for lower-envs
+
+{{- if not .Values.isProd }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
-  name: "{{ .Values.kafkaNodePool.name }}-pool"
+  name: "{{ .Values.combinedPool.name }}"
   labels:
     strimzi.io/cluster: {{ .Values.kafka.name }}
 spec:
-  replicas: {{ .Values.kafkaNodePool.replicas }}
+  replicas: {{ .Values.combinedPool.replicas }}
+  roles:
+    - broker
+    - controller
+  storage:
+    type: jbod
+    volumes:
+    {{- range .Values.combinedPool.storage.volumes }}
+      - id: {{ .id }}
+        type: {{ .type }}
+        size: {{ .size }}
+        deleteClaim: {{ .deleteClaim | default false }}
+    {{- end }}
+
+{{- else }}
+#
+# --- separate nodepools (broker and controllers) for prod env
+# --- Controller Node Pool ---
+#
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: "{{ .Values.controllerPool.name }}"
+  labels:
+    strimzi.io/cluster: {{ .Values.kafka.name }}
+spec:
+  replicas: {{ .Values.controllerPool.replicas }}
   roles:
     - controller
   storage:
-  # jbod give us more flexibility and scalability
     type: jbod
     volumes:
-      {{- range $volume := .Values.kafkaNodePool.storage.volumes }}
-      - id: {{ $volume.id }}
-        type: {{ $volume.type }}
-        size: {{ $volume.size }}
-        deleteClaim: {{ $volume.deleteClaim | default false }}
-      {{- end }}
+    {{- range .Values.controllerPool.storage.volumes }}
+      - id: {{ .id }}
+        type: {{ .type }}
+        size: {{ .size }}
+        deleteClaim: {{ .deleteClaim | default false }}
+    {{- end }}
+---
+#
+# --- Broker Node Pool ---
+#
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: "{{ .Values.brokerPool.name }}"
+  labels:
+    strimzi.io/cluster: {{ .Values.kafka.name }}
+spec:
+  replicas: {{ .Values.brokerPool.replicas }}
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+    {{- range .Values.brokerPool.storage.volumes }}
+      - id: {{ .id }}
+        type: {{ .type }}
+        size: {{ .size }}
+        deleteClaim: {{ .deleteClaim | default false }}
+    {{- end }}
+{{- end }}
+

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -39,7 +39,8 @@ zookeeper:
     size: 100Gi
     deleteClaim: true
 
-isProd: false
+# have a separated controller and broker nodepools
+separatedPools: true
 # ------
 # lower envs pool
 combinedPool:

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -3,6 +3,7 @@ kafka:
   version: 3.9.0
   annotations:
     strimzi.io/kraft: disabled
+    strimzi.io/node-pools: disabled
   replicas: 3
   resources: {}
   listeners:
@@ -38,8 +39,31 @@ zookeeper:
     size: 100Gi
     deleteClaim: true
 
-kafkaNodePool:
-  name: fc-controller
+isProd: false
+# ------
+# lower envs pool
+combinedPool:
+  name: fc-combinedPool
+  replicas: 3
+  storage:
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+# ------
+# prod pools
+controllerPool:
+  name: fc-controllerPool
+  replicas: 3
+  storage:
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 10Gi
+        deleteClaim: false
+brokerPool:
+  name: fc-brokerPool
   replicas: 3
   storage:
     volumes:


### PR DESCRIPTION
# Closes [TECH-620](https://firstclose.atlassian.net/browse/TECH-620)

## :bookmark_tabs: Change Description

different nodepools deployment depending of the env.
With separatedPools: true var would deploy two separated nodepools for broker and controllers. Otherwise it would have both roles in one single nodepool (perfect for lower envs to decrease costs)

## :white_check_mark: Change Introduces

This pull request targets a
- [x] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Support
- [ ] Enhancement

## What type of changes are being introduced?
- [ ] :red_circle: Breaking changes
- [x] :green_circle: Non-breaking changes

## :man_technologist: How should this be tested by QA?
<!--
[Link to Jira ticket with the explanation]()
or
- List 
- of 
- Steps
-->
xxx

## :computer: Pre-requisites to deploy to Production?

<!--
  Is there any pre-requisites to deploy to Staging/Production? If none, please delete this section.

  Example:
  - [ ] Add environment variable to Kubernetes
  - [ ] DB migration
  - [ ] Modify or add a field in CosmosDB
  - [ ] Other Pull Requests are needed
-->

xxx 

## :ledger:	Any background context you want to provide beyond Jira?

xxx

## :camera_flash: Screenshots (if needed)

xxx

## :clapper: Any Video (if needed)

xxx

## :police_officer:	Any possible security issues

xxx


[TECH-620]: https://firstclose.atlassian.net/browse/TECH-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ